### PR TITLE
Some inprovements to the mobile view of the map and the legend

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -13,6 +13,7 @@ html {
     height: 100%;
     min-height: 100vh;
 
+    overflow: hidden;
     font-family: "Poppins";
 }
 
@@ -141,15 +142,15 @@ html {
     }
 
     .legend {
+        position: fixed;
         top: auto;
-        right: auto;
-        left: auto;
+        left: 0;
         bottom: 0;
-        margin: auto;
+        margin: 0;
 
         font-size: 0.9em;
 
-        border-radius: 1 1 0 0;
+        border-radius: 3px 3px 0 0;
     }
 
     .legend-icon {


### PR DESCRIPTION
De kaart wordt op mobiel te groot weergegeven en daardoor blijft hij niet op zijn plaats (groter dan de body). In plaats van de kaart kleiner maken verberg ik het deel dat te groot is zodat toch alles op zijn plek blijft. De legenda heeft nu een position fixed en blijft nu sowieso op zijn plek